### PR TITLE
[hotfix]스토리 좋아요 cascade 수정

### DIFF
--- a/backend/src/main/java/com/hoppy/app/story/domain/story/Story.java
+++ b/backend/src/main/java/com/hoppy/app/story/domain/story/Story.java
@@ -62,7 +62,7 @@ public class Story extends BaseTimeEntity {
     @Exclude
     private Set<StoryReply> replies = new HashSet<>();
 
-    @OneToMany(mappedBy = "story", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "story", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @BatchSize(size = 100)
     @Default
     @Exclude


### PR DESCRIPTION
-스토리가 삭제되면 해당 스토리의 좋아요도 모두 삭제되므로 cascade=REMOVE로 설정